### PR TITLE
Migrate to dita-bootstrap GitHub org

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <a href="https://sass-lang.com"><img src="https://sass-lang.com/assets/img/logos/logo.svg" align="right" width="55"></a>
 
-_DITA Bootstrap Sass_ is a [DITA Open Toolkit plug-in](https://www.dita-ot.org/plugins) that allows you to extend the [DITA Bootstrap](https://infotexture.github.io/dita-bootstrap/) HTML output via [Syntactically Awesome Style Sheets][Sass].
+_DITA Bootstrap Sass_ is a [DITA Open Toolkit plug-in](https://www.dita-ot.org/plugins) that allows you to extend the [DITA Bootstrap](https://dita-bootstrap.github.io/) HTML output via [Syntactically Awesome Style Sheets][Sass].
 
 <!-- MarkdownTOC levels="2,3" -->
 
@@ -40,7 +40,7 @@ See the [DITA-OT documentation](https://www.dita-ot.org/4.0/topics/installing-cl
 
 ```console
 dita install https://github.com/jason-fox/fox.jason.extend.css/archive/master.zip
-dita install https://github.com/infotexture/dita-bootstrap/archive/master.zip
+dita install https://github.com/dita-bootstrap/dita-bootstrap/archive/master.zip
 dita install https://github.com/dita-bootstrap/dita-bootstrap.sass/archive/develop.zip
 ```
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -4,8 +4,8 @@
   This file is part of the DITA Bootstrap Sass plug-in for DITA Open Toolkit.
   See the accompanying LICENSE file for applicable licenses.
 -->
-<plugin id="net.infotexture.dita-bootstrap.sass" version="5.3.5">
-  <require plugin="net.infotexture.dita-bootstrap"/>
+<plugin id="org.dita-bootstrap.sass" version="5.3.5">
+  <require plugin="org.dita-bootstrap.html"/>
   <feature extension="ant.import" file="process_themes.xml"/>
   <feature extension="bootstrap.process.pre" value="bootstrap.sass"/>
   <feature extension="dita.xsl.messages" file="resource/messages.xml"/>

--- a/process_themes.xml
+++ b/process_themes.xml
@@ -4,12 +4,12 @@
   This file is part of the DITA Bootstrap Sass plug-in for DITA Open Toolkit.
   See the accompanying LICENSE file for applicable licenses.
 -->
-<project name="dita.plugin.net.infotexture.dita-bootstrap.sass" xmlns:if="ant:if" xmlns:unless="ant:unless">
+<project name="dita.plugin.org.dita-bootstrap.sass" xmlns:if="ant:if" xmlns:unless="ant:unless">
   <target name="bootstrap.sass" if="bootstrap.sass">
     <macrodef name="incorporate-theme">
       <sequential>
         <condition property="bootstrap.theme.exists">
-          <available file="${dita.plugin.net.infotexture.dita-bootstrap.sass.dir}/sass/theme.css"/>
+          <available file="${dita.plugin.org.dita-bootstrap.sass.dir}/sass/theme.css"/>
         </condition>
 
         <dita-ot-fail unless:set="bootstrap.theme.exists" id="SASS003F"/>
@@ -17,7 +17,7 @@
         <property name="args.copycss" value="yes"/>
         <property name="args.csspath" value="css"/>
         <property name="args.css" value="theme.css"/>
-        <property name="args.cssroot" value="${dita.plugin.net.infotexture.dita-bootstrap.sass.dir}/sass"/>
+        <property name="args.cssroot" value="${dita.plugin.org.dita-bootstrap.sass.dir}/sass"/>
       </sequential>
     </macrodef>
 
@@ -66,7 +66,7 @@
   </target>
 
   <target name="dita2sass-bootstrap" depends="sass.node.check">
-    <property name="dita-bootstrap.sass.dir" value="${dita.plugin.net.infotexture.dita-bootstrap.sass.dir}/sass"/>
+    <property name="dita-bootstrap.sass.dir" value="${dita.plugin.org.dita-bootstrap.sass.dir}/sass"/>
     <available file="${dita-bootstrap.sass.dir}/package-lock.json" property="sass.installed"/>
 
     <exec


### PR DESCRIPTION
- Rename plug-in ID `net.infotexture.dita-bootstrap.sass` → `org.dita-bootstrap.sass` in plugin.xml and the corresponding Ant project name and `${dita.plugin.*.dir}` properties in process_themes.xml.
- Update `<require>` from `net.infotexture.dita-bootstrap` → `org.dita-bootstrap.html`.
- Update README references from `infotexture.github.io/dita-bootstrap` → `dita-bootstrap.github.io` and `github.com/infotexture/*` → `github.com/dita-bootstrap/*`.